### PR TITLE
add attraction type, and can use multiple languages

### DIFF
--- a/scraper/README.md
+++ b/scraper/README.md
@@ -20,12 +20,18 @@ The scraper needs a single environment variable to run: `LOCATION_URL`, which is
 1. Airline: `https://www.tripadvisor.com/Airline_Review-d8729113-Reviews-Lufthansa`
 2. Hotel: `https://www.tripadvisor.com/Hotel_Review-g188107-d231860-Reviews-Beau_Rivage_Palace-Lausanne_Canton_of_Vaud.html`
 3. Restaurant: `https://www.tripadvisor.com/Restaurant_Review-g187265-d11827759-Reviews-La_Terrasse-Lyon_Rhone_Auvergne_Rhone_Alpes.html`
+4. Attraction: `https://www.tripadvisor.com/Attraction_Review-g187261-d1008501-Reviews-Les_Ailes_du_Mont_Blanc-Chamonix_Haute_Savoie_Auvergne_Rhone_Alpes.html`
 
 Note that the URL has to be from  `https://www.tripadvisor.com` and not other TripAdvisor domains such as `.fr`, `.ch`, `.de`, etc.
+
+The scaper may use a `LANGUAGES` environment variable to specify the languages in which to scrape the reviews. The languages should be | and in the format `en|fr|de|es|pt`. If the `LANGUAGES` environment variable is not set, the scraper will default to English.
+
 
 Run using the binary directly:
 ```bash
 export LOCATION_URL=<TripAdvisor_URL>
+# optional
+export LANGUAGES="en|fr|de|es|pt"
 ./binary_name
 ```
 

--- a/scraper/main.go
+++ b/scraper/main.go
@@ -7,15 +7,26 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/algo7/TripAdvisor-Review-Scraper/scraper/pkg/tripadvisor"
 )
 
+// var LANGUAGES = []string{"en", "fr", "pt", "es", "de", "it", "ru", "ja", "zh", "ko", "nl", "sv", "da", "fi", "no", "pl", "hu", "cs", "el", "tr", "th", "ar", "he", "id", "ms", "vi", "tl", "uk", "ro", "bg", "hr", "sr", "sk", "sl", "et", "lv", "lt", "sq", "mk", "hi", "bn", "pa", "gu", "ta", "te", "kn", "ml", "mr", "ur", "fa", "ne", "si", "my", "km", "lo", "am", "ka", "hy", "az", "uz", "tk", "ky", "tg", "mn", "bo", "sd", "ps", "ku", "gl", "eu", "ca", "is", "af", "xh", "zu", "ny", "st", "tn", "sn", "sw", "rw", "so", "mg", "eo", "cy", "gd", "gv", "ga", "mi", "sm", "to", "haw", "id", "jw"}
+var LANGUAGES = []string{"en"}
+
 func main() {
 	// Scraper variables
 	locationURL := os.Getenv("LOCATION_URL")
 	log.Printf("Location URL: %s", locationURL)
+
+	// Get the languages from the environment variable of use "en" as default
+	languages := LANGUAGES
+	if os.Getenv("LANGUAGES") != "" {
+		languages = strings.Split(os.Getenv("LANGUAGES"), "|")
+	}
+	log.Printf("Languages: %v", languages)
 
 	// Get the query type from the URL
 	queryType := tripadvisor.GetURLType(locationURL)
@@ -62,7 +73,7 @@ func main() {
 	}
 
 	// Fetch the review count for the given location ID
-	reviewCount, err := tripadvisor.FetchReviewCount(client, locationID, queryType)
+	reviewCount, err := tripadvisor.FetchReviewCount(client, locationID, queryType, languages)
 	if err != nil {
 		log.Fatalf("Error fetching review count: %v", err)
 	}
@@ -108,7 +119,7 @@ func main() {
 		offset := tripadvisor.CalculateOffset(i)
 
 		// Make the request to the TripAdvisor GraphQL endpoint
-		resp, err := tripadvisor.MakeRequest(client, queryID, "en", locationID, offset, 20)
+		resp, err := tripadvisor.MakeRequest(client, queryID, languages, locationID, offset, 20)
 		if err != nil {
 			log.Fatalf("Error making request at iteration %d: %v", i, err)
 		}

--- a/scraper/pkg/tripadvisor/models.go
+++ b/scraper/pkg/tripadvisor/models.go
@@ -13,6 +13,9 @@ const (
 	// AirlineQueryID is the pre-registered query ID for airline reviews
 	AirlineQueryID string = "83003f8d5a7b1762"
 
+	// AttractionQueryID is the pre-registered query ID for attraction reviews
+	AttractionQueryID string = "b83d781ada1db6f2"
+
 	// ReviewLimit is the maximum number of reviews that can be fetched in a single request
 	ReviewLimit uint32 = 20
 )
@@ -21,6 +24,7 @@ var (
 	tripAdvisorHotelURLRegexp   = regexp.MustCompile(`^https:\/\/www\.tripadvisor\.com\/Hotel_Review-g\d{6,10}-d\d{1,10}-Reviews-[\w-]{1,255}\.html$`)
 	tripAdvisorRestaurantRegexp = regexp.MustCompile(`^https:\/\/www\.tripadvisor\.com\/Restaurant_Review-g\d{6,10}-d\d{1,10}-Reviews-[\w-]{1,255}\.html$`)
 	tripAdvisorAirlineRegexp    = regexp.MustCompile(`^https:\/\/www\.tripadvisor\.com\/Airline_Review-d\d{6,10}-Reviews-[\w-]{1,255}$`)
+	tripAdvisorAttractionRegexp = regexp.MustCompile(`^https:\/\/www\.tripadvisor\.com\/Attraction_Review-g\d{6,10}-d\d{1,10}-Reviews-[\w-]{1,255}\.html$`)
 )
 
 // Filter is a struct that represents the filter object in the request body to TripAdvisor endpoints


### PR DESCRIPTION
Dear Algo7,
For my own use I needed to scrap an attraction in multiple languages,  this is my modifications.
as the variable "LANGUAGES" is not mandatory and languages defaulted to ["en"] it is compatible with your old behavior with "en" hard coded.